### PR TITLE
Move to using the binary version of Espruino

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,6 +1,7 @@
 /* Build file */
 'use strict';
 
+const path = require('path');
 const rollup = require('rollup').rollup;
 const babel = require('rollup-plugin-babel');
 const nodeResolve = require('rollup-plugin-node-resolve');
@@ -30,10 +31,10 @@ module.exports = function build(devices, payload, next) {
             })
         ]
     }).then(bundle => {
-        let result = bundle.generate({
-            format: 'cjs'
+        bundle.write({
+            format: 'cjs',
+            dest: path.join(payload.buildDir, 'espruino-generated.js')
         });
-        payload.code = result.code;
         next();
     }).catch(next);
 };

--- a/build.js
+++ b/build.js
@@ -31,9 +31,14 @@ module.exports = function build(devices, payload, next) {
             })
         ]
     }).then(bundle => {
-        bundle.write({
+        return bundle.write({
             format: 'cjs',
             dest: path.join(payload.buildDir, 'espruino-generated.js')
-        }).then(next);
+        }).then(next)
+          .catch(err => {
+            console.log("Problems during bundling, continuing...", err);
+            next();
+        });
+
     }).catch(next);
 };

--- a/build.js
+++ b/build.js
@@ -34,7 +34,6 @@ module.exports = function build(devices, payload, next) {
         bundle.write({
             format: 'cjs',
             dest: path.join(payload.buildDir, 'espruino-generated.js')
-        });
-        next();
+        }).then(next);
     }).catch(next);
 };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-es2015-rollup": "^1.1.1",
-    "espruino": "0.0.18",
+    "espruino": "0.0.20",
     "rollup": "^0.34.1",
     "rollup-plugin-babel": "^2.6.1",
     "rollup-plugin-json": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "esprima": "^3.0.0",
+    "istanbul": "^0.4.5",
     "mocha": "^2.5.3",
-    "istanbul": "^0.4.5"
+    "tmp": "0.0.29"
   },
   "author": "Andrew Chalkley <andrew@chalkley.org>",
   "license": "MIT",

--- a/repl.js
+++ b/repl.js
@@ -1,5 +1,6 @@
 'use strict';
 const spawn = require('child_process').spawn;
+const utils = require('./utils');
 
 module.exports = function repl(device) {
     console.log('Connecting REPL...');
@@ -10,14 +11,7 @@ module.exports = function repl(device) {
         detached: true
     });
 
-    function output(msg) {
-        msg = "" + msg;
-        // Avoid cases where it is re-printing exactly what we are typing
-        if (msg.endsWith("\n")) {
-            msg = `${device.runtime}:  ${msg}`;
-        }
-        process.stdout.write(msg);
-    }
+    let output = utils.outputForDevice(device);
 
     espruinoCmd.stdout.on('data', data => {
          output(data.toString());

--- a/repl.js
+++ b/repl.js
@@ -6,27 +6,5 @@ const utils = require('./utils');
 module.exports = function repl(device) {
     console.log('Connecting REPL...');
 
-    let espruinoCmd = spawn('node', [path.join('node_modules', 'espruino', 'bin', 'espruino-cli'), '-b', device.baud_rate], {
-        // Because spawned processes don't support setRawMode we need to pass our stdin thru
-        stdio: ['inherit', 'pipe', 'pipe'],
-        detached: true
-    });
-
-    let output = utils.outputForDevice(device);
-
-    espruinoCmd.stdout.on('data', data => {
-        output(data.toString());
-    });
-
-    espruinoCmd.stderr.on('data', data => {
-        output(data.toString());
-    });
-
-    espruinoCmd.on('close', code => {
-        output('Exited with status ' + code);
-    });
-
-    espruinoCmd.on('error', err => {
-        console.error(`Error: ${err.message}`);
-    });
+    utils.runEspruino(device);
 };

--- a/repl.js
+++ b/repl.js
@@ -27,6 +27,6 @@ module.exports = function repl(device) {
     });
 
     espruinoCmd.on('error', err => {
-        output(`Error: ${err.message}`);
+        console.error(`Error: ${err.message}`);
     });
 };

--- a/repl.js
+++ b/repl.js
@@ -1,10 +1,7 @@
 'use strict';
-const path = require('path');
-const spawn = require('child_process').spawn;
 const utils = require('./utils');
 
 module.exports = function repl(device) {
     console.log('Connecting REPL...');
-
     utils.runEspruino(device);
 };

--- a/repl.js
+++ b/repl.js
@@ -1,11 +1,12 @@
 'use strict';
+const path = require('path');
 const spawn = require('child_process').spawn;
 const utils = require('./utils');
 
 module.exports = function repl(device) {
     console.log('Connecting REPL...');
 
-    let espruinoCmd = spawn('espruino', ['-b', device.baud_rate], {
+    let espruinoCmd = spawn('node', [path.join('node_modules', 'espruino', 'bin', 'espruino-cli'), '-b', device.baud_rate], {
         // Because spawned processes don't support setRawMode we need to pass our stdin thru
         stdio: ['inherit', 'pipe', 'pipe'],
         detached: true
@@ -14,14 +15,18 @@ module.exports = function repl(device) {
     let output = utils.outputForDevice(device);
 
     espruinoCmd.stdout.on('data', data => {
-         output(data.toString());
+        output(data.toString());
     });
 
     espruinoCmd.stderr.on('data', data => {
-         output(data.toString());
+        output(data.toString());
     });
 
     espruinoCmd.on('close', code => {
         output('Exited with status ' + code);
+    });
+
+    espruinoCmd.on('error', err => {
+        output(`Error: ${err.message}`);
     });
 };

--- a/test/test_build.js
+++ b/test/test_build.js
@@ -1,16 +1,55 @@
 'use strict';
 
+const fs = require('fs');
 const assert = require('chai').assert;
 const {build} = require('../index');
-const path = require('path');
 const esprima = require('esprima');
+const path = require('path');
+const tmp = require('tmp');
+
+tmp.setGracefulCleanup();
+
+function getTmpDir() {
+    let tmpObj = tmp.dirSync({unsafeCleanup: true});
+    return tmpObj.name;
+}
+
+function assertBuildsSuccessfully(pathToEntry, expectedCode, done) {
+    let buildDir = getTmpDir();
+    let payload = {
+        entry: pathToEntry,
+        buildDir: buildDir
+    };
+    build({}, payload, () => {
+        let generated = fs.readFileSync(path.join(payload.buildDir, 'espruino-generated.js')).toString();
+        const tokens = esprima.tokenize(generated);
+        const expectedTokens = esprima.tokenize(expectedCode);
+        assert.deepEqual(tokens, expectedTokens, 'Generated code matches tokens');
+        done();
+    });
+}
+
+function assertBuildFails(pathToEntry, done) {
+    let buildDir = getTmpDir();
+    let payload = {
+        entry: pathToEntry,
+        buildDir: buildDir
+    };
+    build({}, payload, (err) => {
+        assert.isNotNull(err);
+        let fileCount = fs.readdirSync(buildDir).length;
+        // No file created
+        assert.equal(0, fileCount);
+        done();
+    });
+}
 
 describe('build(devices, payload, next)', function () {
+
     describe('when entry is a valid source file', () => {
-        const payload = { entry: path.join('test', 'examples', 'multi-level-include', 'index.js') };
-        it('should return valid ES5 code', (done) => {
-            build({}, payload, () => { 
-                const expectedCode = `
+        it('should return valid ES5 code', done => {
+            const pathToEntry = path.join('test', 'examples', 'multi-level-include', 'index.js');
+            const expectedCode = `
                 'use strict';
                 function multiply(a, b) {
                     return a * b;
@@ -20,65 +59,45 @@ describe('build(devices, payload, next)', function () {
                 }
                 var a = square(10);
                 console.log(a);`;
-                const tokens = esprima.tokenize(payload.code);
-                const expectedTokens = esprima.tokenize(expectedCode);
-                assert.deepEqual(tokens, expectedTokens, "Code generated did't match expected code");
-                done();
-            });
+            assertBuildsSuccessfully(pathToEntry, expectedCode, done);
         });
     });
 
     describe('when entry is a valid source file with an imported json file', () => {
-        const payload = { entry: path.join('test', 'examples', 'multi-level-include', 'json-include.js') };
-        it('should return valid ES5 code', (done) => {
-            build({}, payload, () => {
-                const expectedCode = `
-                'use strict';
-                function divide(a, b) {
-                    return a / b;
-                }
-                var val = 100;
-                var a = divide(200, val);
-                console.log(a);`;
-                const tokens = esprima.tokenize(payload.code);
-                const expectedTokens = esprima.tokenize(expectedCode);
-                assert.deepEqual(tokens, expectedTokens, "Code generated did't match expected code");
-                done();
-            });
+        it('should return valid ES5 code', done => {
+            const pathToEntry = path.join('test', 'examples', 'multi-level-include', 'json-include.js');
+            const expectedCode = `
+            'use strict';
+            function divide(a, b) {
+                return a / b;
+            }
+            var val = 100;
+            var a = divide(200, val);
+            console.log(a);`;
+            assertBuildsSuccessfully(pathToEntry, expectedCode, done);
         });
     });
 
     describe('when entry is a invalid source file', () => {
-        const payload = { entry: path.join('test', 'examples', 'invalid-code', 'index.js') };
+        let pathToEntry = path.join('test', 'examples', 'invalid-code', 'index.js');
 
         it('should error', (done) => {
-            build({}, payload, (err) => {
-                assert.isNotNull(err);
-                assert.equal(payload.code, undefined);
-                done();
-            });
+            let pathToEntry = path.join('test', 'examples', 'invalid-code', 'index.js');
+            assertBuildFails(pathToEntry, done);
         });
     });
 
     describe('when entry\'s import cannot be resolved', () => {
-        const payload = { entry: path.join('test', 'examples', 'invalid-code', 'unresolved.js') };
         it('should throw an error', (done) => {
-            build({}, payload, (err) => {
-                assert.isNotNull(err);
-                assert.equal(payload.code, undefined);
-                done();
-            });
+            let pathToEntry = path.join('test', 'examples', 'invalid-code', 'unresolved.js');
+            assertBuildFails(pathToEntry, done);
         });
     });
 
     describe('when entry is an invalid path file', () => {
         it('should error', (done) => {
-            const payload = { entry: path.join('test', 'examples', 'invalid-code', 'doesnt-exist.js') };
-            build({}, payload, (err) => {
-                assert.isNotNull(err);
-                assert.equal(payload.code, undefined);
-                done();
-            });
+            let pathToEntry = path.join('test', 'examples', 'invalid-code', 'doesnt-exist.js');
+            assertBuildFails(pathToEntry, done);
         });
     });
 });

--- a/upload.js
+++ b/upload.js
@@ -1,44 +1,13 @@
 /* Upload file */
 'use strict';
 const path = require('path');
-const espruino = require('espruino');
 const utils = require('./utils');
 
 
 function uploadToDevice(device, filePath) {
     console.log(`Sending code to device - ${device.port} @ ${device.baud_rate} baud...`);
 
-    const spawn = require('child_process').spawn;
-
-    let output = utils.outputForDevice(device);
-
-    let espruinoCmd = spawn('node', [
-        path.join('node_modules', 'espruino', 'bin', 'espruino-cli'), 
-        '-b', device.baud_rate,
-        '-p', device.port,
-        '-c',
-        filePath
-    ], {
-            // Because spawned processes don't support setRawMode we need to pass our stdin thru
-            stdio: ['inherit', 'pipe', 'pipe'],
-            detached: true
-        });
-
-    espruinoCmd.stdout.on('data', data => {
-        output(data.toString());
-    });
-
-    espruinoCmd.stderr.on('data', data => {
-        output(data.toString());
-    });
-
-    espruinoCmd.on('close', code => {
-        output(`Exited with status ${code}`);
-    });
-
-    espruinoCmd.on('error', err => {
-        console.error(`Error: ${err.message}`);
-    });
+    utils.runEspruino(device, '-c', filePath);
 }
 
 module.exports = function upload(devices, payload, next) {

--- a/upload.js
+++ b/upload.js
@@ -37,7 +37,7 @@ function uploadToDevice(device, filePath) {
     });
 
     espruinoCmd.on('error', err => {
-        output(`Error: ${err.message}`);
+        console.error(`Error: ${err.message}`);
     });
 }
 

--- a/upload.js
+++ b/upload.js
@@ -12,27 +12,32 @@ function uploadToDevice(device, filePath) {
 
     let output = utils.outputForDevice(device);
 
-    let espruinoCmd = spawn('espruino', [
+    let espruinoCmd = spawn('node', [
+        path.join('node_modules', 'espruino', 'bin', 'espruino-cli'), 
         '-b', device.baud_rate,
         '-p', device.port,
         '-c',
         filePath
-        ], {
+    ], {
             // Because spawned processes don't support setRawMode we need to pass our stdin thru
             stdio: ['inherit', 'pipe', 'pipe'],
             detached: true
         });
 
     espruinoCmd.stdout.on('data', data => {
-         output(data.toString());
+        output(data.toString());
     });
 
     espruinoCmd.stderr.on('data', data => {
-         output(data.toString());
+        output(data.toString());
     });
 
     espruinoCmd.on('close', code => {
-        output('Exited with status ' + code);
+        output(`Exited with status ${code}`);
+    });
+
+    espruinoCmd.on('error', err => {
+        output(`Error: ${err.message}`);
     });
 }
 

--- a/upload.js
+++ b/upload.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const utils = require('./utils');
 
-
 function uploadToDevice(device, filePath) {
     console.log(`Sending code to device - ${device.port} @ ${device.baud_rate} baud...`);
 

--- a/upload.js
+++ b/upload.js
@@ -1,26 +1,45 @@
 /* Upload file */
 'use strict';
+const path = require('path');
 const espruino = require('espruino');
 const utils = require('./utils');
 
 
-function uploadToDevice(device, code) {
+function uploadToDevice(device, filePath) {
     console.log(`Sending code to device - ${device.port} @ ${device.baud_rate} baud...`);
-    utils.mute((unmute) => {
-        espruino.init(() => {
-            Espruino.Config.BAUD_RATE = device.baud_rate;
-            espruino.sendCode(device.port, code, () => {
-                unmute();
-                console.log(`Code sent to ${device.port}`);
-                // FIXME: Espruino is holding the process open
-                process.exit();
-            });
+
+    const spawn = require('child_process').spawn;
+
+    let output = utils.outputForDevice(device);
+
+    let espruinoCmd = spawn('espruino', [
+        '-b', device.baud_rate,
+        '-p', device.port,
+        '-c',
+        filePath
+        ], {
+            // Because spawned processes don't support setRawMode we need to pass our stdin thru
+            stdio: ['inherit', 'pipe', 'pipe'],
+            detached: true
         });
+
+    espruinoCmd.stdout.on('data', data => {
+         output(data.toString());
+    });
+
+    espruinoCmd.stderr.on('data', data => {
+         output(data.toString());
+    });
+
+    espruinoCmd.on('close', code => {
+        output('Exited with status ' + code);
     });
 }
 
 module.exports = function upload(devices, payload, next) {
     let espruinoDevices = utils.filterDevices(devices);
-    espruinoDevices.forEach(device => uploadToDevice(device, payload.code));
+    espruinoDevices.forEach(device => {
+        return uploadToDevice(device, path.join(payload.buildDir, 'espruino-generated.js'));
+    });
     next();
 };

--- a/utils.js
+++ b/utils.js
@@ -1,15 +1,5 @@
 'use strict';
 
-/**
- * Espruino libraries use console.log directly.  This silences code in `fn` until the `callback` is called.
- */
-function mute(fn) {
-    let oldLog = console.log;
-    console.log = Function.prototype;
-    fn.call(null, () => {
-        console.log = oldLog;
-    });
-}
 
 
 function filterDevices(devices) {
@@ -18,7 +8,19 @@ function filterDevices(devices) {
             .map(port => Object.assign({port}, devices[port]));
 }
 
+// This is a curried function (I think)
+function outputForDevice(device) {
+    return (msg) => {
+        msg = "" + msg;
+        // Avoid cases where it is re-printing exactly what we are typing
+        if (msg.endsWith("\n")) {
+            msg = `${device.runtime}:  ${msg}`;
+        }
+        process.stdout.write(msg);
+    };
+}
+
 module.exports = {
     filterDevices,
-    mute
+    outputForDevice
 };

--- a/utils.js
+++ b/utils.js
@@ -25,8 +25,7 @@ function runEspruino(device, ...cmdLineArgs) {
         ...cmdLineArgs
     ], {
             // Because spawned processes don't support setRawMode we need to pass our stdin thru
-            stdio: ['inherit', 'pipe', 'pipe'],
-            detached: true
+            stdio: ['inherit', 'pipe', 'pipe']
         });
 
     espruinoCmd.stdout.on('data', data => {

--- a/utils.js
+++ b/utils.js
@@ -9,9 +9,8 @@ function filterDevices(devices) {
             .map(port => Object.assign({port}, devices[port]));
 }
 
-// This is a curried function (I think)
-function outputForDevice(device) {
-    return (msg) => {
+function runEspruino(device, ...cmdLineArgs) {
+    let output = function(msg) {
         msg = "" + msg;
         // Avoid cases where it is re-printing exactly what we are typing
         if (msg.endsWith("\n")) {
@@ -19,10 +18,6 @@ function outputForDevice(device) {
         }
         process.stdout.write(msg);
     };
-}
-
-function runEspruino(device, ...cmdLineArgs) {
-    let output = outputForDevice(device);
     let espruinoCmd = spawn('node', [
         path.join('node_modules', 'espruino', 'bin', 'espruino-cli'),
         '-b', device.baud_rate,
@@ -55,6 +50,5 @@ function runEspruino(device, ...cmdLineArgs) {
 
 module.exports = {
     filterDevices,
-    outputForDevice,
     runEspruino
 };


### PR DESCRIPTION
Since functionality is available at the command line already using `espruino`, this code switches to relying on that instead of internal node packages.  

This reduces noise and lines up more with how interaction with other runtimes will most likely shake out.

This requires https://github.com/thingsSDK/thingssdk-cli/pull/21 to be merged.

